### PR TITLE
Получить устройства, когда колонка не привязана ни к одной комнате

### DIFF
--- a/custom_components/yandex_station_intents/yandex_quasar.py
+++ b/custom_components/yandex_station_intents/yandex_quasar.py
@@ -129,6 +129,9 @@ class YandexQuasar:
         for dev in resp['unconfigured_devices']:
             self.devices.append(Device.from_dict(dev))
 
+        for dev in resp['speakers']:
+            self.devices.append(Device.from_dict(dev))
+            
         for room in resp['rooms']:
             room_name = room['name']
 


### PR DESCRIPTION
Ситуация, когда колонка не привязана ни к одной из комнат.
Кейс очень редкий, но имеет место быть.

![image](https://github.com/dext0r/ha-yandex-station-intents/assets/10882718/c25bc182-d960-4dab-8d2e-c4dfee364172)

Сценарии в аккаунте создаются и обновляются, а интенты не срабатывают - просто нет реакции, потому что не находит устройство, когда приходит сообщение по веб-сокету, там device получается "пустой"

![image](https://github.com/dext0r/ha-yandex-station-intents/assets/10882718/3c9b1d29-821b-4bf3-88ea-a18e57badd34)
