### PR TITLE
fix 403 error

### DIFF
--- a/custom_components/yandex_station_intents/__init__.py
+++ b/custom_components/yandex_station_intents/__init__.py
@@ -273,3 +273,5 @@ async def _async_setup_intents(
             break
         except Exception:
             _LOGGER.exception(f"Ошибка создания или обновления сценария {item.scenario_name!r}")
+        if index < len(intents) - 1:
+            await asyncio.sleep(90.0)


### PR DESCRIPTION
Заметил в логах ошибки, понял что при уменьшение кол-ва сценариев ошибка уходит, в итоге просто добавил паузу в цикле, ошибка 403 из логов ушла